### PR TITLE
Fixed a problem for high DPI device. Added round cube.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,9 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/type_ptr.hpp>
 #include <iostream>
 #include <iterator>
 #include <vector>
@@ -29,8 +32,11 @@ static std::string read_shader(const std::filesystem::path::value_type *path) {
 
 int main(int argc, char **argv, char **envp) {
     int success;
-    const int width = 512;
-    const int height = 768/2;
+    const int width = 1024;
+    const int height = 768;
+    int framebufferWidth = 0;
+    int framebufferHeight = 0;
+    int resolution[] = {width, height};
     if (!glfwInit()) {
         fprintf(stderr, "failed to init\n");
     }
@@ -40,15 +46,17 @@ int main(int argc, char **argv, char **envp) {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 #ifdef __APPLE__
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif
 
     GLFWwindow *window;
     window = glfwCreateWindow(width, height, "LessTriangle", NULL, NULL);
 
+    glfwGetFramebufferSize(window, &resolution[0], &resolution[1]);
+    
     if (window == NULL) {
         fprintf(stderr, "failed to create window\n");
         glfwTerminate();
@@ -62,7 +70,7 @@ int main(int argc, char **argv, char **envp) {
         fprintf(stderr, "failed to init glew.\n");
         return -1;
     }
-
+    
     glfwSetInputMode(window, GLFW_STICKY_KEYS, GL_TRUE);
 
     const float vertices[] = {
@@ -174,8 +182,7 @@ int main(int argc, char **argv, char **envp) {
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void *)0);
     glEnableVertexAttribArray(0);
     // glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
-    glUniform2f(glGetUniformLocation(shader_program, "resolution"), (GLfloat)width, (GLfloat)height);
-
+    glUniform2iv(glGetUniformLocation(shader_program, "resolution"), 1, resolution);
     do {
         glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         glClear(GL_COLOR_BUFFER_BIT);

--- a/src/shader/cube.frag
+++ b/src/shader/cube.frag
@@ -25,3 +25,20 @@ vec4 cube(vec3 v, vec3 p, vec3 size, vec3 color) {
     // if the point is inside the box
     return vec4(di, color);
 }
+
+vec4 rounded_cube(vec3 v, vec3 p, vec3 size, vec3 color, float r) {
+    vec3 d = abs(v - p) - size;  // size = (l, w, h),
+                                 // d.axis < 0 means the corresponding
+                                 // point is inside the box
+    d.x = max(d.x, 0);
+    d.y = max(d.y, 0);
+    d.z = max(d.z, 0);
+    float di = min(max(d.x, max(d.y, d.z)), 0.0) + length(d) - r;
+    // notice that we use abs() before
+    // then length(d) will return the distance to the surface of cube
+    // if the point is outside the box.
+    // min(max(d.x, max(d.y, d.z)), 0.0) will return 0
+    // if the point is inside the box
+    return vec4(di, color);
+}
+

--- a/src/shader/main_frag.frag
+++ b/src/shader/main_frag.frag
@@ -6,11 +6,12 @@
 #define DEBUG_SDF    false
 
 out vec4 FragColor; // gl style...
-uniform vec2 resolution;
+uniform ivec2 resolution;
 
 // geometry
 vec4 sphere_sdf(vec3 v, vec3 p, float r, vec3 color);
 vec4 cube(vec3 v, vec3 p, vec3 size, vec3 color);
+vec4 rounded_cube(vec3 v, vec3 p, vec3 size, vec3 color, float r);
 
 // light
 vec3 ambient_light(vec3, vec3, float);
@@ -31,7 +32,7 @@ vec4 min4(vec4 a, vec4 b) {
  * @return Distance from the ray to the scene
  */
 vec4 scene(vec3 v) {
-    vec4 sdf1 = cube(v, vec3(0, 0, 5), vec3(1, 1, 1), vec3(1, 0, 0));
+    vec4 sdf1 = rounded_cube(v, vec3(0, 0, 5), vec3(1, 1, 1), vec3(1, 0, 0), 0.5);
     vec4 sdf2 = sphere_sdf(v, vec3(1, 2, 5), 1.0, vec3(0, 1, 0));
     vec4 sdf3 = sphere_sdf(v, vec3(-1, 2, 5), 1.0, vec3(0, 0, 1));
     vec4 res = min4(sdf1, sdf2);
@@ -86,8 +87,10 @@ vec4 ray_march(vec3 start, vec3 dir) {
 
 void main() {
     // FragColor = vec4(0.5, 0.6, 0.7, 1.0);
-    vec2 uv = (gl_FragCoord.xy - resolution.xy) / resolution.x;
-    vec3 ro = vec3(0, 3, 0);
+    vec2 __resolution = resolution;
+    vec2 ratio = vec2(__resolution.x / __resolution.y, 1.0);
+    vec2 uv = ratio * (gl_FragCoord.xy / __resolution.xy - 0.5);
+    vec3 ro = vec3(0, 0, 0);
     vec3 rd = normalize(vec3(uv.x, uv.y, 1.));
 
     vec4 res = ray_march(ro, rd);
@@ -111,3 +114,4 @@ void main() {
         }
     }
 }
+


### PR DESCRIPTION
The framebuffer size of High DPI display, for example, Retina display of Apple, is different from the size of window. `glfwGetFramebufferSize()` should be called to retrieve the correct framebuffer size.